### PR TITLE
feat: モバイル時のヘッダー動的表示を実装

### DIFF
--- a/frontend/src/components/ui/Header.tsx
+++ b/frontend/src/components/ui/Header.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { ThemeToggle } from '../theme/ThemeToggle';
@@ -10,12 +10,42 @@ import { Menu, X } from 'lucide-react';
 const Header: React.FC = () => {
   const [isScrolled, setIsScrolled] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isHeaderVisible, setIsHeaderVisible] = useState(true);
   const pathname = usePathname();
   const { theme, setTheme } = useTheme();
+  const lastScrollY = useRef(0);
 
   useEffect(() => {
     const handleScroll = () => {
-      setIsScrolled(window.scrollY > 10);
+      const currentScrollY = window.scrollY;
+      setIsScrolled(currentScrollY > 10);
+
+      // YouTubeプレーヤーの位置を検出
+      const youtubePlayer = document.querySelector('.youtube-player-container');
+      
+      if (youtubePlayer && window.innerWidth < 768) { // モバイルサイズの場合のみ
+        const playerRect = youtubePlayer.getBoundingClientRect();
+        const headerHeight = document.querySelector('.fixed-header')?.getBoundingClientRect().height || 0;
+        
+        // YouTubeプレーヤーの上部とヘッダーの下部が接触したかどうか
+        const isPlayerTouchingHeader = playerRect.top <= headerHeight;
+        
+        // スクロール方向を検出
+        const isScrollingDown = currentScrollY > lastScrollY.current;
+        
+        // プレーヤーがヘッダーに接触していて、下にスクロールしている場合はヘッダーを非表示
+        if (isPlayerTouchingHeader && isScrollingDown) {
+          setIsHeaderVisible(false);
+        } else if (!isScrollingDown) {
+          // 上にスクロールしている場合はヘッダーを表示
+          setIsHeaderVisible(true);
+        }
+      } else {
+        // モバイルサイズでない場合は常に表示
+        setIsHeaderVisible(true);
+      }
+      
+      lastScrollY.current = currentScrollY;
     };
 
     window.addEventListener('scroll', handleScroll);
@@ -31,7 +61,7 @@ const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   return (
-    <header className="fixed-header bg-background/80 dark:bg-background/90 border-b border-border">
+    <header className={`fixed-header bg-background/80 dark:bg-background/90 border-b border-border transition-transform duration-300 ${!isHeaderVisible ? '-translate-y-full' : 'translate-y-0'}`}>
       <div className="container mx-auto px-4 h-full flex items-center justify-between">
         <Link href="/" className="flex items-center space-x-2">
           <span className="text-xl font-bold gradient-text">マッチアップファインダー</span>


### PR DESCRIPTION
- YouTubeプレーヤーとヘッダーの相互作用を考慮した動的な表示制御を追加
- スクロール方向に応じてヘッダーを自動的に非表示/表示
- モバイルサイズ時のみ、プレーヤーとヘッダーの接触を検出
- トランジションアニメーションを追加し、よりスムーズな表示切り替えを実現