### PR TITLE
fix: YouTubeプレーヤーの再初期化プロセスを改善

### DIFF
--- a/frontend/src/components/player/YouTubePlayer.tsx
+++ b/frontend/src/components/player/YouTubePlayer.tsx
@@ -75,6 +75,20 @@ const YouTubePlayer: React.FC<YouTubePlayerProps> = ({
       if (playerRef.current) {
         playerRef.current.destroy();
         playerInitializedRef.current = false;
+        
+        // プレーヤーの破棄後、DOMの更新を確実にするために少し待つ
+        const playerElement = document.getElementById('youtube-player');
+        if (playerElement) {
+          // 既存の要素を削除して再作成
+          const parentElement = playerElement.parentElement;
+          if (parentElement) {
+            parentElement.removeChild(playerElement);
+            const newPlayerElement = document.createElement('div');
+            newPlayerElement.id = 'youtube-player';
+            newPlayerElement.className = 'w-full h-full';
+            parentElement.appendChild(newPlayerElement);
+          }
+        }
       }
       
       // 少し遅延させてから再初期化
@@ -96,7 +110,7 @@ const YouTubePlayer: React.FC<YouTubePlayerProps> = ({
         });
         
         playerInitializedRef.current = true;
-      }, 100);
+      }, 300); // 100ミリ秒から300ミリ秒に増やす
     }
   }, [url, autoplay]);
 
@@ -214,7 +228,7 @@ const YouTubePlayer: React.FC<YouTubePlayerProps> = ({
   return (
     <div className="youtube-player-container border border-border dark:border-gray-800 bg-black aspect-ratio-16/9 w-full h-full" style={containerStyle}>
       {embedUrl ? (
-        <div id="youtube-player" className="w-full h-full"></div>
+        <div id="youtube-player" className="w-full h-full" key={embedUrl}></div>
       ) : (
         <LoadingIndicator />
       )}

--- a/frontend/src/hooks/useVideoSelection.ts
+++ b/frontend/src/hooks/useVideoSelection.ts
@@ -58,7 +58,7 @@ const useVideoSelection = (videos: MatchupVideo[], allVideos: MatchupVideo[]) =>
         if (foundVideo) {
           setCurrentVideo(foundVideo);
         }
-      }, 50);
+      }, 300);
     }
   }, [videos, allVideos]);
 


### PR DESCRIPTION
- プレーヤー破棄後のDOM更新処理を追加
- 動画切り替え時の遅延時間を調整（100ms → 300ms）
- YouTubeプレーヤーの再初期化の安定性を向上
- キーを使用して動的なコンポーネント再レンダリングを実装