### PR TITLE
feat: 事前にキャラクター画像を読み込むカスタムフックを追加

### DIFF
--- a/frontend/src/components/character/CharacterIcons.tsx
+++ b/frontend/src/components/character/CharacterIcons.tsx
@@ -28,7 +28,6 @@ const SingleCharacterIcon: React.FC<SingleCharacterIconProps> = ({
           src={icon.path}
           alt={`${icon.eng} icon`}
           className="w-full h-full object-cover"
-          loading="lazy"
         />
       </div>
       <div className="absolute inset-0 bg-black bg-opacity-0 group-hover:bg-opacity-20 transition-opacity duration-200 rounded-lg" />

--- a/frontend/src/components/character/CharacterSelector.tsx
+++ b/frontend/src/components/character/CharacterSelector.tsx
@@ -9,6 +9,7 @@ import {
   filterCharacterIcons,
   characterIcons
 } from '../../data/characterData';
+import { usePreloadCharacterImages } from '../../hooks/usePreloadCharacterImages';
 
 // キャラクターの表示用コンポーネント
 interface CharacterDisplayProps {
@@ -266,6 +267,9 @@ const CharacterSelector: React.FC<CharacterSelectorProps> = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectionMode, setSelectionMode] = useState<'single' | 'multiple'>('single');
   const [searchTerm, setSearchTerm] = useState('');
+
+  // ページ初期表示時にアイドル状態でキャラクター画像を事前読み込み
+  usePreloadCharacterImages();
 
   // モーダルが閉じたら検索欄をクリア
   useEffect(() => {

--- a/frontend/src/hooks/usePreloadCharacterImages.ts
+++ b/frontend/src/hooks/usePreloadCharacterImages.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { characterIcons } from '../data/characterData';
+
+/**
+ * キャラクターアイコン画像をブラウザのアイドル時間に事前読み込みするカスタムフック
+ * これにより、モーダル表示時のちらつきを防止します
+ */
+export function usePreloadCharacterImages() {
+  const preloadedRef = useRef(false);
+
+  useEffect(() => {
+    // 既にプリロード済みの場合はスキップ
+    if (preloadedRef.current) return;
+
+    const preloadImages = () => {
+        console.log('preloadImages');
+      characterIcons.forEach((icon) => {
+        const img = new Image();
+        img.src = icon.path;
+      });
+      preloadedRef.current = true;
+    };
+
+    // ブラウザがアイドル状態の時に画像をプリロード
+    if ('requestIdleCallback' in window) {
+      const idleCallbackId = requestIdleCallback(
+        () => {
+          preloadImages();
+        },
+        { timeout: 2000 } // 最大2秒待っても実行されなければ強制実行
+      );
+
+      return () => {
+        cancelIdleCallback(idleCallbackId);
+      };
+    } else {
+      // Safari等、requestIdleCallbackをサポートしていないブラウザ向けのフォールバック
+      const timeoutId = setTimeout(preloadImages, 200);
+
+      return () => {
+        clearTimeout(timeoutId);
+      };
+    }
+  }, []);
+}
+
+export default usePreloadCharacterImages;
+


### PR DESCRIPTION
キャラクター選択モーダルを初回表示時にキャラクターアイコンが事前読み込みできておらず、不快感があったため、ユーザーが不快感を覚えないように事前にアイコン画像をフェッチするように修正。

- usePreloadCharacterImagesフックを実装し、ブラウザのアイドル時間にキャラクターアイコン画像を事前読み込み
- CharacterSelectorコンポーネントでフックを使用し、モーダル表示時のちらつきを防止
- CharacterIconsコンポーネントから不要なloading属性を削除