### PR TITLE
feat: YouTubeプレーヤーのタイムスタンプシーク機能を改善し、状態管理を最適化

### DIFF
--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -22,7 +22,14 @@ export default {
     },
     container: {
       center: true,
-      padding: 'xs:1rem', // 必要に応じてパディングを設定
+      padding: {
+        DEFAULT: '1rem',
+        xs: '1rem',
+        sm: '1.5rem',
+        md: '2rem',
+        lg: '2rem',
+        xl: '2rem',
+      },
       screens: {       
         sm: '1200px',        
         xl: '1280px',


### PR DESCRIPTION
同じ動画内のタイムスタンプ移動でも別動画扱いで切り替えが発生しており、ユーザー体験がとても悪かったため修正。

- タイムスタンプ変更時の動画IDチェックを追加し、同じ動画内でのシークを実装
- 動画変更中のフラグ管理を改善し、不要な再初期化を防止
- useVideoSelectionフックのロジックを整理し、動画IDの比較を強化
- Tailwind CSSのコンテナパディング設定を詳細化